### PR TITLE
Fe/ahyeon -> dev

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -47,7 +47,7 @@ function App() {
       element: <Root logged={logged} currUser={currUser} />,
       children: [
         { index: true, element: <Home /> }, // index가 true인 컴포넌트는 Root의 Outlet에 기본으로 보여짐
-        { path: '/questions', element: <Questions /> },
+        { path: '/question', element: <Questions /> },
       ],
     },
     {
@@ -91,7 +91,7 @@ function App() {
           element: <UserDetail currUser={currUser} userList={userList} />,
         },
         { path: '/edit', element: <EditQuestion /> },
-        { path: '/questions/:id', element: <DetailQuestion /> },
+        { path: '/question/:id', element: <DetailQuestion /> },
       ],
     },
   ]);

--- a/client/src/Components/Nav/Nav.jsx
+++ b/client/src/Components/Nav/Nav.jsx
@@ -90,7 +90,7 @@ const Nav = () => {
               }
             >
               <BiWorld className="icon" size={16} />
-              <a href="/questions">Questions</a>
+              <a href="/question">Questions</a>
             </li>
             <li
               className={

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -30,7 +30,7 @@ module.exports = function (app) {
       })
     ),
     app.use(
-      '/questions',
+      '/question',
       createProxyMiddleware({
         target: `${process.env.REACT_APP_API_URL}`,
         changeOrigin: true,


### PR DESCRIPTION
다시 만난 Whitelabel Error 퇴치했습니다.
루트 화면 페이지 주소와 특정 GET API 호출 주소가 중복되어 발생한 이슈라고 하네요...

[참고](https://woonys.tistory.com/entry/GET-API-route-%EC%A4%91%EB%B3%B5-issue-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0-%EC%8A%A4%ED%94%84%EB%A7%81%EB%B6%80%ED%8A%B8%EC%99%80-React%EB%8A%94-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%86%B5%EC%8B%A0%ED%95%98%EB%82%98Feat-Tomcat)